### PR TITLE
Add support for immortal objects.

### DIFF
--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -15,6 +15,18 @@ extern "C" {
 PyAPI_FUNC(int) _PyType_CheckConsistency(PyTypeObject *type);
 PyAPI_FUNC(int) _PyDict_CheckConsistency(PyObject *mp, int check_content);
 
+/* An "immortal" object is one for which Py_DECREF() will never try
+ * to deallocate it.  To achieve this we set the refcount to some
+ * negative value.  To play it safe, we use a value right in the
+ * middle of the negative range.
+ */
+
+PyAPI_FUNC(int) _PyObject_IsImmortal(PyObject *);
+PyAPI_FUNC(int) _PyObject_SetImmortal(PyObject *);
+PyAPI_FUNC(void) _PyObject_ClearImmortal(PyObject *);
+PyAPI_FUNC(PyObject *) _PyObject_GetActualTypeHolder(PyObject *);
+PyAPI_FUNC(PyTypeObject *) _PyObject_GetActualType(PyObject *);
+
 /* Update the Python traceback of an object. This function must be called
    when a memory block is reused from a free list.
 

--- a/Include/object.h
+++ b/Include/object.h
@@ -128,8 +128,11 @@ static inline Py_ssize_t _Py_REFCNT(const PyObject *ob) {
 #define Py_REFCNT(ob) _Py_REFCNT(_PyObject_CAST_CONST(ob))
 
 
+extern PyObject * _PyObject_GetActualTypeHolder(PyObject *);
+
 // bpo-39573: The Py_SET_TYPE() function must be used to set an object type.
-#define Py_TYPE(ob)             (_PyObject_CAST(ob)->ob_type)
+#define Py_TYPE(ob) \
+    (_PyObject_GetActualTypeHolder(_PyObject_CAST(ob))->ob_type)
 
 // bpo-39573: The Py_SET_SIZE() function must be used to set an object size.
 #define Py_SIZE(ob)             (_PyVarObject_CAST(ob)->ob_size)
@@ -148,6 +151,11 @@ static inline void _Py_SET_REFCNT(PyObject *ob, Py_ssize_t refcnt) {
 
 
 static inline void _Py_SET_TYPE(PyObject *ob, PyTypeObject *type) {
+    extern int _PyObject_IsImmortal(PyObject *);
+    extern void _PyObject_ClearImmortal(PyObject *);
+    if (_PyObject_IsImmortal(ob)) {
+        _PyObject_ClearImmortal(ob);
+    }
     ob->ob_type = type;
 }
 #define Py_SET_TYPE(ob, type) _Py_SET_TYPE(_PyObject_CAST(ob), type)


### PR DESCRIPTION
We take a relatively hacky approach of sticking a dummy object into an immortal objects `ob_type`.

Also see https://github.com/ericsnowcurrently/cpython/pull/6.