### PR TITLE
Globals immortal objects flags

### DIFF
--- a/Doc/c-api/refcounting.rst
+++ b/Doc/c-api/refcounting.rst
@@ -119,3 +119,69 @@ The following functions or macros are only for use within the interpreter core:
 :c:func:`_Py_Dealloc`, :c:func:`_Py_ForgetReference`, :c:func:`_Py_NewReference`,
 as well as the global variable :c:data:`_Py_RefTotal`.
 
+.. _immortal-objects:
+
+Immortal Objects
+================
+
+"Immortal" objects are those that are expected to never be deallocated
+by the runtime (due to their reference count reaching 0).  In the public
+C-API examples of such objects includes the singletons and many builtin
+types.  For such objects the reference count is essentially irrelevant.
+Immortal objects are especially useful if otherwise immutable.
+
+Note that for now the API for immortal objects is not available
+for general use, by default.  Users of the public C-API (but not
+the limited API) may opt in by defining ``_Py_IMMORTAL_OBJECTS``.
+This API should not be considered stable yet.
+
+.. c:function:: int _PyObject_IsImmortal(PyObject *o)
+
+   Return non-zero if the object is immortal.
+
+   .. versionadded:: 3.10
+
+.. c:function:: void _PyObject_SetImmortal(PyObject *o)
+
+   Mark an object as immortal.
+
+   .. versionadded:: 3.10
+
+.. c:macro:: _PyObject_IMMORTAL_BIT
+
+   This is the bit in the reference count value that indicates whether
+   or not the object is immortal.
+
+   This is for internal use only.  Instead use
+   :c:func:`_PyObject_IsImmortal` and
+   :c:func:`_PyObject_IsImmortal`.
+
+   .. versionadded:: 3.10
+
+.. c:macro:: _PyObject_IMMORTAL_INIT_REFCNT
+
+   This is the reference count value to which immortal objects
+   are initialized.
+
+   This is for internal use only.  Instead use
+   :c:func:`_PyObject_IsImmortal` and
+   :c:func:`_PyObject_IsImmortal`.
+
+   .. versionadded:: 3.10
+
+Also see :c:macro:`_PyObject_HEAD_IMMORTAL_INIT` and
+:c:macro:`_PyVarObject_HEAD_IMMORTAL_INIT`.
+
+.. _immutable-refcounts:
+
+Immutable Refcounts
+-------------------
+
+If ``Py_IMMORTAL_CONST_REFCOUNTS`` is defined then the following
+happens:
+
+* the immortal objects API is enabled
+* the runtime never changes reference counts for immortal objects
+
+This mode can help with copy-on-write semantics when forking.
+

--- a/Doc/c-api/structures.rst
+++ b/Doc/c-api/structures.rst
@@ -98,6 +98,7 @@ the definition of all other Python objects.
 .. c:function:: void Py_SET_REFCNT(PyObject *o, Py_ssize_t refcnt)
 
    Set the object *o* reference counter to *refcnt*.
+   :ref:`immortal-objects` are not affected.
 
    .. versionadded:: 3.9
 
@@ -133,6 +134,39 @@ the definition of all other Python objects.
 
       _PyObject_EXTRA_INIT
       1, type, size,
+
+
+.. c:macro:: _PyObject_HEAD_IMMORTAL_INIT(type)
+
+   This is a macro which expands to initialization values for a new
+   :c:type:`PyObject` type.  It makes the object
+   :ref:`immortal <immortal-objects>`.  This macro expands to::
+
+      _PyObject_EXTRA_INIT
+      _PyObject_IMMORTAL_INIT_REFCNT, type,
+
+   For now you must opt in to use this by defining
+   ``_Py_IMMORTAL_OBJECTS``.
+
+   .. versionadded:: 3.10
+
+
+.. c:macro:: PyVarObject_HEAD_IMMORTAL_INIT(type, size)
+
+   This is a macro which expands to initialization values for a new
+   :c:type:`PyVarObject` type, including the :attr:`ob_size` field.
+   It makes the object :ref:`immortal <immortal-objects>`.  This
+   macro expands to::
+
+      _PyObject_EXTRA_INIT
+      _PyObject_IMMORTAL_INIT_REFCNT, type, size,
+
+   This is especially useful for static types.
+
+   For now you must opt in to use this by defining
+   ``_Py_IMMORTAL_OBJECTS``.
+
+   .. versionadded:: 3.10
 
 
 Implementing functions and methods

--- a/Include/cpython/object.h
+++ b/Include/cpython/object.h
@@ -375,6 +375,32 @@ PyAPI_FUNC(PyObject *) _PyObject_FunctionStr(PyObject *);
         Py_XDECREF(_py_tmp);                    \
     } while (0)
 
+/* An "immortal" object is one for which Py_DECREF() will never try
+ * to deallocate it.  To achieve this we set the refcount to some
+ * negative value.  To play it safe, we use a value right in the
+ * middle of the negative range.
+ */
+
+#ifdef Py_BUILD_CORE
+#define _Py_IMMORTAL_OBJECTS 1
+#endif
+
+#ifdef _Py_IMMORTAL_OBJECTS
+#define _PyObject_IMMORTAL_BIT (PY_SSIZE_T_MAX / -4)
+
+// We leave plenty of room to preserve _PyObject_IMMORTAL_BIT.
+#define _PyObject_IMMORTAL_INIT_REFCNT \
+    (_PyObject_IMMORTAL_BIT + (_PyObject_IMMORTAL_BIT / 2))
+
+#define _PyObject_HEAD_IMMORTAL_INIT(type) \
+    { _PyObject_EXTRA_INIT _PyObject_IMMORTAL_INIT_REFCNT, type },
+#define _PyVarObject_HEAD_IMMORTAL_INIT(type, size) \
+    { PyObject_HEAD_IMMORTAL_INIT(type) size },
+
+PyAPI_FUNC(int) _PyObject_IsImmortal(PyObject *);
+PyAPI_FUNC(void) _PyObject_SetImmortal(PyObject *);
+#endif
+
 
 PyAPI_DATA(PyTypeObject) _PyNone_Type;
 PyAPI_DATA(PyTypeObject) _PyNotImplemented_Type;

--- a/Include/cpython/object.h
+++ b/Include/cpython/object.h
@@ -377,8 +377,8 @@ PyAPI_FUNC(PyObject *) _PyObject_FunctionStr(PyObject *);
 
 /* An "immortal" object is one for which Py_DECREF() will never try
  * to deallocate it.  To achieve this we set the refcount to some
- * negative value.  To play it safe, we use a value right in the
- * middle of the negative range.
+ * positive value that we would never expect to be reachable through
+ * use of Py_INCREF() in a program.
  */
 
 #ifdef Py_BUILD_CORE
@@ -386,7 +386,10 @@ PyAPI_FUNC(PyObject *) _PyObject_FunctionStr(PyObject *);
 #endif
 
 #ifdef _Py_IMMORTAL_OBJECTS
-#define _PyObject_IMMORTAL_BIT (PY_SSIZE_T_MAX / -4)
+/* The GC bit-shifts refcounts left by two, and after that shift we still
+ * need this to be >> 0, so leave three high zero bits (the sign bit and
+ * room for a shift of two.) */
+#define _PyObject_IMMORTAL_BIT (1LL << (8 * sizeof(Py_ssize_t) - 4))
 
 // We leave plenty of room to preserve _PyObject_IMMORTAL_BIT.
 #define _PyObject_IMMORTAL_INIT_REFCNT \

--- a/Include/cpython/object.h
+++ b/Include/cpython/object.h
@@ -381,7 +381,7 @@ PyAPI_FUNC(PyObject *) _PyObject_FunctionStr(PyObject *);
  * use of Py_INCREF() in a program.
  */
 
-#ifdef Py_BUILD_CORE
+#if defined(Py_IMMORTAL_CONST_REFCOUNTS) || defined(Py_BUILD_CORE)
 #define _Py_IMMORTAL_OBJECTS 1
 #endif
 
@@ -391,9 +391,14 @@ PyAPI_FUNC(PyObject *) _PyObject_FunctionStr(PyObject *);
  * room for a shift of two.) */
 #define _PyObject_IMMORTAL_BIT (1LL << (8 * sizeof(Py_ssize_t) - 4))
 
+#ifdef Py_IMMORTAL_CONST_REFCOUNTS
+#define _PyObject_IMMORTAL_INIT_REFCNT \
+    _PyObject_IMMORTAL_BIT
+#else
 // We leave plenty of room to preserve _PyObject_IMMORTAL_BIT.
 #define _PyObject_IMMORTAL_INIT_REFCNT \
     (_PyObject_IMMORTAL_BIT + (_PyObject_IMMORTAL_BIT / 2))
+#endif
 
 #define _PyObject_HEAD_IMMORTAL_INIT(type) \
     { _PyObject_EXTRA_INIT _PyObject_IMMORTAL_INIT_REFCNT, type },

--- a/Include/object.h
+++ b/Include/object.h
@@ -122,12 +122,6 @@ typedef struct {
 #define _PyVarObject_CAST_CONST(op) ((const PyVarObject*)(op))
 
 static inline Py_ssize_t _Py_REFCNT(const PyObject *ob) {
-    extern int _PyObject_IsImmortal(PyObject *);
-    if (_PyObject_IsImmortal((PyObject *)ob)) {
-        // The value is somewhat arbitrary.  It just needs
-        // to be positive and sufficiently far from 0.
-        return 1LL << (8 * sizeof(Py_ssize_t) - 4);
-    }
     return ob->ob_refcnt;
 }
 #define Py_REFCNT(ob) _Py_REFCNT(_PyObject_CAST_CONST(ob))

--- a/Include/object.h
+++ b/Include/object.h
@@ -476,14 +476,7 @@ static inline void _Py_DECREF(
     if (--op->ob_refcnt != 0) {
 #ifdef Py_REF_DEBUG
         if (op->ob_refcnt < 0) {
-#ifdef Py_IMMORTAL_CONST_REFCOUNTS
             _Py_NegativeRefcount(filename, lineno, op);
-#else
-            extern int _PyObject_IsImmortal(PyObject *);
-            if (!_PyObject_IsImmortal(op)) {
-                _Py_NegativeRefcount(filename, lineno, op);
-            }
-#endif
         }
 #endif
     }

--- a/Misc/NEWS.d/next/Core and Builtins/2021-03-11-13-03-15.bpo-40255._1LfiG.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-03-11-13-03-15.bpo-40255._1LfiG.rst
@@ -1,0 +1,6 @@
+There is now internal support for "immortal" objects.  Those are objects
+that will never be deleted, like the singletons and static types.  This has
+benefits for the C-API and subinterpreters, as well as allowing for better
+copy-on-write behavior for forking (if Py_IMMORTAL_CONST_REFCOUNTS is used).
+The feature is currently intended for internal use, though you can try it
+out by building with _Py_IMMORTAL_OBJECTS defined.

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -142,8 +142,10 @@ _PyObject_IsImmortal(PyObject *ob)
     if ((ob->ob_refcnt & _PyObject_IMMORTAL_BIT) == 0) {
         return 0;
     }
+#ifndef Py_IMMORTAL_CONST_REFCOUNTS
     // Reset it to avoid approaching the boundaries.
     _PyObject_SetImmortal(ob);
+#endif
     return 1;
 }
 

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -142,10 +142,6 @@ _PyObject_IsImmortal(PyObject *ob)
     if ((ob->ob_refcnt & _PyObject_IMMORTAL_BIT) == 0) {
         return 0;
     }
-#ifndef Py_IMMORTAL_CONST_REFCOUNTS
-    // Reset it to avoid approaching the boundaries.
-    _PyObject_SetImmortal(ob);
-#endif
     return 1;
 }
 

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -146,7 +146,9 @@ _PyType_CheckConsistency(PyTypeObject *type)
         return 1;
     }
 
-    CHECK(Py_REFCNT(type) >= 1);
+    if (!_PyObject_IsImmortal((PyObject *)type)) {
+        CHECK(Py_REFCNT(type) >= 1);
+    }
     CHECK(PyType_Check(type));
 
     CHECK(!(type->tp_flags & Py_TPFLAGS_READYING));


### PR DESCRIPTION
This is a branch I started in December, before I found python#19474.  My approach wasn't actually terribly different from what Eddie proposed.  After finding that PR I updated this one a little bit, borrowing some of the details there.

Notable differences from Eddie's PR:
* as much code as possible limited to the internal header files
* no touches to `_Py_INCREF()`
* instead of trying to keep the refcount at the magic tag, keep it at-or-above it (and reset to the tag occasionally)
* enabled by default in the runtime and opt-in for the public C-API
* I left changes to static types out

Note that I haven't looked at this code for a while.  There are probably a number of tweaks to make before posting this upstream.

(An alternative approach, albeit probably not ultimately viable, involves sticking a dummy type in `ob_type`: https://github.com/python/cpython/compare/master...ericsnowcurrently:globals-immortal-objects-obtype)