### PR TITLE
Adjust docs for ``tp_subclasses``

### DIFF
--- a/Doc/c-api/typeobj.rst
+++ b/Doc/c-api/typeobj.rst
@@ -1928,16 +1928,17 @@ and :c:type:`PyType_Type` effectively act as defaults.)
    This field is not inherited.
 
 
-.. c:member:: PyObject* PyTypeObject.tp_subclasses
+.. c:member:: void* PyTypeObject.tp_subclasses
 
-   The collection of weak references to subclasses.  Internal use only.
+   A collection of subclasses.  Internal use only.  May be an invalid pointer.
+
+   To get a list of subclasses, call the Python method
+   :py:meth:`~class.__subclasses__`.
 
    .. versionchanged:: 3.12
 
-      Internals detail: For the static builtin types this field no longer
-      holds the subclasses.  Those are now stored on ``PyInterpreterState``.
-      For static builtin types, this field is re-purposed to hold the index
-      into the type's storage on each interpreter state.
+      For some types, this field does not hold a valid :c:expr:`PyObject*`.
+      The type was changed to :c:expr:`void*` to indicate this.
 
    **Inheritance:**
 

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -420,13 +420,15 @@ Porting to Python 3.12
   using the existing public C-API instead, or, if necessary, the
   (internal-only) ``_PyObject_GET_WEAKREFS_LISTPTR()`` macro.
 
-* ``tp_subclasses`` is no longer used for any static builtin types.
-  The subclasses are stored internally elsewhere.  However, ``tp_subclasses``
-  may still hold data that will cause a crash if used as an object pointer.
-  This internal-only ``PyTypeObject`` field should not be used.  Use the
-  exist public C-API or Python API to access ``__subclasses__`` instead.
-  We mention this in case anyone someone happens to be accessing the
-  field directly anyway.
+* This internal-only :c:member:`PyTypeObject.tp_subclasses` may now not be
+  a valid object pointer.  Its type was changed to :c:expr:`void *` to
+  reflect this.  We mention this in case someone happens to be accessing the
+  internal-only field directly.
+
+  To get a list of subclasses, call the Python method
+  :py:meth:`~class.__subclasses__` (using :c:func:`PyObject_CallMethod`,
+  for example).
+
 
 Deprecated
 ----------


### PR DESCRIPTION
(I started nitpicking as suggestions in #95301, but wanted to build the docs to check the syntax.)
Here's how I'd write the docs:

- Member documentation describes the current state, for users.
- The ``versionchanged`` note describes the change.
- The What's New entry is, ideally, usable for someone stuck with
  maintaining a mysterious legacy codebase that stopped working.

Details of internals are left out -- if it isn't enough to look
at the source, they should be documented in the devguide rather
than user-facing docs.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
